### PR TITLE
Fix travis_wait command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ before_install:
 install:
 - ./travisScripts/install.sh
 script:
-- "travis_wait 70 sleep 1800 &"
-- ./travisScripts/build.sh
+- travis_wait 70 ./travisScripts/build.sh


### PR DESCRIPTION
Hi there! This is Luna from Travis CI. I've made an edit to your `.travis.yml` file to correct the misconstructed `travis_wait` command. An accompanying email will follow. This extends the silence timeout to 70 minutes but if another value works for you, feel free to change it. :)